### PR TITLE
Fix sendForm definition.

### DIFF
--- a/htmlTmpl.py
+++ b/htmlTmpl.py
@@ -169,7 +169,7 @@ function broadcastMsg(brd) {
     document.getElementById("to").disabled = brd;
 }
 
-function sendForm(id, conf = false) {
+function sendForm(id, conf) {
     if (conf) {
         if (! confirm(conf)) return false;
     }


### PR DESCRIPTION
This caused a Javascript error in Chromium, resulting in the whole page breaking. Arguments not passed to Javascript functions are `undefined` by default, which evaluates to `false` in an `if` statement. Providing a default value like this does not work and is also unnecessary.